### PR TITLE
defined namespaces separately for compatibility purposes

### DIFF
--- a/core/core/definitions.h
+++ b/core/core/definitions.h
@@ -2,26 +2,32 @@
 
 #include <cstdint>
 
-namespace com::teamspeak {
+namespace com
+{
+namespace teamspeak
+{
 
-using connection_id_t = uint64_t;
-using channel_id_t = uint64_t;
-using client_id_t = uint16_t;
-using permission_id_t = uint32_t;
-using permission_group_id_t = uint64_t;
-using client_db_id_t = uint64_t;
-using transfer_id_t = uint16_t;
+    using connection_id_t = uint64_t;
+    using channel_id_t = uint64_t;
+    using client_id_t = uint16_t;
+    using permission_id_t = uint32_t;
+    using permission_group_id_t = uint64_t;
+    using client_db_id_t = uint64_t;
+    using transfer_id_t = uint16_t;
 
-enum class Group_Category : uint8_t {
-    Server,
-    Channel,
-    Client,
-    ChannelClient
-};
+    enum class Group_Category : uint8_t
+    {
+        Server,
+        Channel,
+        Client,
+        ChannelClient
+    };
 
-enum Group_List_Type {
-    Server,
-    Channel
-};
+    enum Group_List_Type
+    {
+        Server,
+        Channel
+    };
 
-} // namespace com::teamspeak
+}  // namespace teamspeak
+}  // namespace com

--- a/core/core/plugin_helpers.h
+++ b/core/core/plugin_helpers.h
@@ -2,9 +2,12 @@
 
 #include <filesystem>
 
-namespace teamspeak::plugin
+namespace teamspeak
 {
-    enum class Path {
+namespace plugin
+{
+    enum class Path
+    {
         App = 0,
         Config,
         Resources,
@@ -12,4 +15,5 @@ namespace teamspeak::plugin
     };
 
     std::filesystem::path get_path(Path path);
-}
+}  // namespace plugin
+}  // namespace teamspeak

--- a/core/core/ts_error.h
+++ b/core/core/ts_error.h
@@ -287,10 +287,13 @@ enum class ts_errc
 #endif
 };
 
-namespace com::teamspeak
+namespace com
 {
-ts_errc to_ts_errc(uint32_t err);
+namespace teamspeak
+{
+    ts_errc to_ts_errc(uint32_t err);
 }
+}  // namespace com
 
 namespace std
 {

--- a/volume/volume/volumes.h
+++ b/volume/volume/volumes.h
@@ -12,25 +12,29 @@
 #include <memory>
 #include <utility>
 
-namespace thorwe::volume
+namespace thorwe
+{
+namespace volume
 {
 
-using namespace com::teamspeak;
+    using namespace com::teamspeak;
 
-template <typename T = DspVolume> class Volumes final : public Safe_Client_Storage<T>
-{
-
-  public:
-    std::pair<T *, bool> add_volume(connection_id_t connection_id, client_id_t client_id)
+    template <typename T = DspVolume> class Volumes final : public Safe_Client_Storage<T>
     {
-        return add_item(connection_id, client_id, std::make_unique<T>());
-    }
 
-    void onConnectStatusChanged(connection_id_t connection_id, int new_status, unsigned int /*error_number*/)
-    {
-        if (ConnectStatus::STATUS_DISCONNECTED == new_status)
-            delete_items(connection_id);
-    }
-};
+      public:
+        std::pair<T *, bool> add_volume(connection_id_t connection_id, client_id_t client_id)
+        {
+            return add_item(connection_id, client_id, std::make_unique<T>());
+        }
 
-}  // namespace thorwe::volume
+        void
+        onConnectStatusChanged(connection_id_t connection_id, int new_status, unsigned int /*error_number*/)
+        {
+            if (ConnectStatus::STATUS_DISCONNECTED == new_status)
+                delete_items(connection_id);
+        }
+    };
+
+}  // namespace volume
+}  // namespace thorwe


### PR DESCRIPTION
cmake automoc was failing when com::teamspeak and throve::volume was
defined as nested namespaces and had to be defined separately